### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/StudyMode.tsx
+++ b/src/pages/StudyMode.tsx
@@ -9,8 +9,13 @@ import {
 } from '@/components/ui/card';
 import { studyNotes } from '@/data/studyNotes';
 
+type SpeechRecognitionConstructor = typeof window.SpeechRecognition;
+
 const SpeechRecognition =
-  (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+  window.SpeechRecognition ||
+  (window as Window & {
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }).webkitSpeechRecognition;
 
 const StudyMode: React.FC = () => {
   const [step, setStep] = useState(0);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix no-empty-interface violations in command and textarea
- remove explicit `any` usage in StudyMode
- migrate require to import in Tailwind config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687063c8bc608327892257b2179717f0