### PR TITLE
Add text-to-speech capability

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { User, Bot } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import AudioPlayer from './AudioPlayer';
+import { useTTS } from '@/hooks/useTTS';
 
 export interface Message {
   id: string;
@@ -18,6 +19,7 @@ interface ChatMessageProps {
 
 const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
   const isUser = message.type === 'user';
+  useTTS(message.content, message.type);
 
   return (
     <div className={`flex gap-3 ${isUser ? 'flex-row-reverse' : 'flex-row'} mb-4`}>

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -11,6 +11,7 @@ import TypingIndicator from '@/components/TypingIndicator';
 import { useLangChainRAG } from '@/hooks/useLangChainRAG';
 import { useRAG } from '@/hooks/useRAG';
 import { toast } from '@/hooks/use-toast';
+import { useTTSToggle } from '@/hooks/useTTS';
 import { STUDY_MODE_PROMPT, QUIZ_MODE_PROMPT } from '@/data/systemPrompts';
 
 interface ChatWindowProps {
@@ -22,6 +23,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ mode }) => {
   const [inputText, setInputText] = useState('');
   const [isTyping, setIsTyping] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { get: getTTS, set: setTTS } = useTTSToggle();
 
 // Add-system-prompts-for-study-and-quiz-modes
   const { generateResponse } = useRAG();
@@ -162,6 +164,14 @@ main
         
         <div className="text-xs text-muted-foreground mt-2 text-center">
           Press Enter to send
+          <label className="flex items-center gap-2 justify-center mt-2">
+            <input
+              type="checkbox"
+              defaultChecked={getTTS()}
+              onChange={e => setTTS(e.target.checked)}
+            />
+            🔈 Read answers aloud
+          </label>
         </div>
       </div>
     </Card>

--- a/src/components/VoiceQuiz.tsx
+++ b/src/components/VoiceQuiz.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import { speak } from '@/lib/voice';
 
 interface Question {
   prompt: string;
@@ -25,11 +26,6 @@ const VoiceQuiz: React.FC = () => {
   const [feedback, setFeedback] = useState('');
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
-  const speak = (text: string) => {
-    const utterance = new SpeechSynthesisUtterance(text);
-    window.speechSynthesis.cancel();
-    window.speechSynthesis.speak(utterance);
-  };
 
   const startListening = () => {
     const SpeechRecognitionImpl = window.SpeechRecognition || window.webkitSpeechRecognition;

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { speak } from '@/lib/voice'
+
+const KEY = 'tts-enabled'
+
+export function useTTS(text: string, role: 'user' | 'assistant') {
+  useEffect(() => {
+    const enabled = localStorage.getItem(KEY) === 'true'
+    if (role === 'assistant' && enabled && text) speak(text)
+  }, [text, role])
+}
+
+export function useTTSToggle() {
+  const get = () => localStorage.getItem(KEY) === 'true'
+  const set = (val: boolean) => localStorage.setItem(KEY, String(val))
+  return { get, set }
+}

--- a/src/lib/voice.ts
+++ b/src/lib/voice.ts
@@ -1,0 +1,62 @@
+export interface SpeakOpts {
+  voiceName?: string;
+  rate?: number;   // default 1
+  pitch?: number;  // default 1
+  volume?: number; // default 1
+}
+
+function pickVoice(name?: string): SpeechSynthesisVoice | null {
+  const voices = window.speechSynthesis.getVoices();
+  if (!voices.length) return null;
+  return (
+    voices.find(v => v.name === name) ||
+    voices.find(v => /Google/.test(v.name)) ||
+    voices[0]
+  );
+}
+
+import { toast } from '@/hooks/use-toast';
+
+export function speak(text: string, opts: SpeakOpts = {}) {
+  if (!('speechSynthesis' in window)) return;
+
+  const voicesReady = window.speechSynthesis.getVoices().length;
+  if (!voicesReady) {
+    window.speechSynthesis.addEventListener('voiceschanged', () =>
+      speak(text, opts)
+    );
+    return;
+  }
+
+  try {
+    window.speechSynthesis.cancel();
+
+    const voice = pickVoice(opts.voiceName);
+    const { rate = 1, pitch = 1, volume = 1 } = opts;
+
+    const sentences = text.match(/[^.!?]+[.!?]*/g) || [text];
+    const chunks: string[] = [];
+    let current = '';
+    for (const sentence of sentences) {
+      if ((current + sentence).length > 200) {
+        if (current.trim()) chunks.push(current.trim());
+        current = sentence;
+      } else {
+        current += sentence;
+      }
+    }
+    if (current.trim()) chunks.push(current.trim());
+
+    for (const chunk of chunks) {
+      const utterance = new SpeechSynthesisUtterance(chunk);
+      if (voice) utterance.voice = voice;
+      utterance.rate = rate;
+      utterance.pitch = pitch;
+      utterance.volume = volume;
+      window.speechSynthesis.speak(utterance);
+    }
+  } catch (err) {
+    console.error('TTS error', err);
+    toast({ description: 'Text-to-speech unavailable on this device.' });
+  }
+}

--- a/src/pages/StudyMode.tsx
+++ b/src/pages/StudyMode.tsx
@@ -9,6 +9,7 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { studyNotes } from '@/data/studyNotes';
+import { speak } from '@/lib/voice';
 
 const StudyMode: React.FC = () => {
   const [step, setStep] = useState(0);
@@ -21,8 +22,7 @@ const StudyMode: React.FC = () => {
     setAiResponse(null);
     setUnderstood(false);
     if (!note) return;
-    const utterance = new SpeechSynthesisUtterance(note.content);
-    speechSynthesis.speak(utterance);
+    speak(note.content);
   }, [step, note]);
 
   useEffect(() => {
@@ -64,7 +64,7 @@ const StudyMode: React.FC = () => {
     const prompt = `Rephrase or simplify the following explanation:\n\n${note.content}`;
     const result = await callOpenAI(prompt);
     setAiResponse(result);
-    speechSynthesis.speak(new SpeechSynthesisUtterance(result));
+    speak(result);
   };
 
   const handleAnalogy = async () => {
@@ -72,7 +72,7 @@ const StudyMode: React.FC = () => {
     const prompt = `Provide an analogy to help a student understand: ${note.content}`;
     const result = await callOpenAI(prompt);
     setAiResponse(result);
-    speechSynthesis.speak(new SpeechSynthesisUtterance(result));
+    speak(result);
   };
 
   const handleNext = () => {


### PR DESCRIPTION
## Summary
- core TTS utilities using Web Speech API
- hook and toggle to speak assistant replies
- integrate TTS in chat messages
- update existing components to use TTS helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68712a7047788327b9d51ae5b1f8b12c